### PR TITLE
Bump commons-collections in /stockmarket/cloud-user-service

### DIFF
--- a/stockmarket/cloud-user-service/pom.xml
+++ b/stockmarket/cloud-user-service/pom.xml
@@ -37,7 +37,7 @@
 		<dependency>
 			<groupId>commons-collections</groupId>
 			<artifactId>commons-collections</artifactId>
-			<version>3.2.1</version>
+			<version>3.2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-lang</groupId>


### PR DESCRIPTION
Bumps commons-collections from 3.2.1 to 3.2.2.

Signed-off-by: dependabot[bot] <support@github.com>